### PR TITLE
Add ApiFilters component for filtering APIs by category and difficulty

### DIFF
--- a/src/components/ApiFilters.vue
+++ b/src/components/ApiFilters.vue
@@ -1,0 +1,61 @@
+<template>
+  <div class="filters-bar">
+    <select v-model="selectedCategory" class="filter-select">
+      <option value="">Todas las categorías</option>
+      <option v-for="cat in categories" :key="cat" :value="cat">{{ cat }}</option>
+    </select>
+    <select v-model="selectedDifficulty" class="filter-select">
+      <option value="">Todas las dificultades</option>
+      <option v-for="diff in difficulties" :key="diff" :value="diff">Dificultad {{ diff }}</option>
+    </select>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch, computed } from 'vue'
+const props = defineProps({
+  apis: {
+    type: Array,
+    required: true
+  }
+})
+const emit = defineEmits(['filter'])
+
+const selectedCategory = ref('')
+const selectedDifficulty = ref('')
+
+const categories = computed(() => {
+  return [...new Set(props.apis.map(api => api.Category))].sort()
+})
+const difficulties = computed(() => {
+  return [...new Set(props.apis.map(api => api.Difficulty))].sort((a, b) => a - b)
+})
+
+watch([selectedCategory, selectedDifficulty], () => {
+  emit('filter', {
+    category: selectedCategory.value,
+    difficulty: selectedDifficulty.value
+  })
+})
+</script>
+
+<style scoped>
+.filters-bar {
+  display: flex;
+  gap: 18px;
+  margin-bottom: 24px;
+}
+.filter-select {
+  padding: 8px 14px;
+  border-radius: 8px;
+  border: 1px solid #ddd;
+  font-size: 1rem;
+  background: #f8fafc;
+  color: #222;
+  outline: none;
+  transition: border 0.18s;
+}
+.filter-select:focus {
+  border-color: #f26c21;
+}
+</style>


### PR DESCRIPTION
Se creó el componente reutilizable ApiFilters para filtrar APIs por categoría y dificultad, calculando dinámicamente las opciones a partir de los datos del JSON.
Se integró ApiFilters en Home.vue, aplicando los filtros junto con la búsqueda de texto, manteniendo la lógica reactiva y el código limpio.
Los filtros se actualizan automáticamente si se agregan nuevas categorías o dificultades en apis.json, sin necesidad de modificar el código.
El diseño y la experiencia de usuario son coherentes con el resto de la aplicación.